### PR TITLE
Better Error Tracking

### DIFF
--- a/lib/sheng.rb
+++ b/lib/sheng.rb
@@ -1,6 +1,14 @@
-
 require 'active_support/inflector'
 require 'active_support/core_ext/hash'
+require 'zip'
+require 'nokogiri'
+require 'fileutils'
+require 'json'
+
+module Sheng
+  class Error < StandardError; end
+end
+
 require 'sheng/support'
 require 'sheng/version'
 require 'sheng/data_set'
@@ -12,11 +20,3 @@ require 'sheng/merge_field'
 require 'sheng/sequence'
 require 'sheng/conditional_block'
 require 'sheng/check_box'
-
-require 'zip'
-require 'nokogiri'
-require 'fileutils'
-require 'json'
-
-module Sheng
-end

--- a/lib/sheng/block.rb
+++ b/lib/sheng/block.rb
@@ -1,7 +1,7 @@
 module Sheng
   class Block < MergeFieldSet
-    class MissingEndTag < StandardError; end
-    class ImproperNesting < StandardError; end
+    class MissingEndTag < Docx::TemplateError; end
+    class ImproperNesting < Docx::TemplateError; end
 
     def initialize(merge_field)
       @start_field = merge_field

--- a/lib/sheng/check_box.rb
+++ b/lib/sheng/check_box.rb
@@ -1,6 +1,6 @@
 module Sheng
   class CheckBox
-    attr_reader :element, :xml_document
+    attr_reader :element, :xml_document, :errors
 
     class << self
       def from_element(element)
@@ -11,6 +11,7 @@ module Sheng
     def initialize(element = nil)
       @element = element
       @xml_document = element.document
+      @errors = []
     end
 
     def ==(other)
@@ -29,7 +30,8 @@ module Sheng
       value = data_set.fetch(key)
       checked_attribute = @element.search('.//w:default').first.attribute('val')
       checked_attribute.value = value_is_truthy?(value) ? '1' : '0'
-    rescue DataSet::KeyNotFound
+    rescue DataSet::KeyNotFound => e
+      @errors << e
       # Ignore this error; if the key for this checkbox is not found in the
       # data set, we don't want to uncheck the checkbox; we just want to leave
       # it alone.

--- a/lib/sheng/data_set.rb
+++ b/lib/sheng/data_set.rb
@@ -29,7 +29,7 @@ module Sheng
           if options.has_key?(:default)
             value = options[:default]
           else
-            raise KeyNotFound, "did not find in dataset: #{key} (#{key_part} not found)"
+            raise KeyNotFound, "#{key} (at #{key_part})"
           end
         end
         if (i + 1) < key_parts.length

--- a/lib/sheng/data_set.rb
+++ b/lib/sheng/data_set.rb
@@ -1,6 +1,6 @@
 module Sheng
   class DataSet
-    class KeyNotFound < StandardError; end
+    class KeyNotFound < Sheng::Error; end
 
     attr_accessor :raw_hash
 

--- a/lib/sheng/docx.rb
+++ b/lib/sheng/docx.rb
@@ -4,10 +4,10 @@
 #
 module Sheng
   class Docx
-    class InvalidFile < StandardError; end
-    class TemplateError < StandardError; end
-    class FileAlreadyExists < StandardError; end
-    class GenerateError < StandardError; end
+    class InvalidFile < Sheng::Error; end
+    class TemplateError < Sheng::Error; end
+    class OutputPathAlreadyExists < Sheng::Error; end
+    class MergeError < Sheng::Error; end
 
     WMLFileNamePatterns = [
       /word\/document.xml/,
@@ -44,13 +44,13 @@ module Sheng
 
     def generate(path, force: false)
       if File.exists?(path) && !force
-        raise FileAlreadyExists, "File at #{path} already exists"
+        raise OutputPathAlreadyExists, "File at #{path} already exists"
       end
 
       output_buffer = generate_output_buffer
 
       if errors.present?
-        raise GenerateError.new(errors)
+        raise MergeError.new(errors)
       end
 
       File.open(path, "w") { |f| f.write(output_buffer.string) }

--- a/lib/sheng/filters.rb
+++ b/lib/sheng/filters.rb
@@ -1,6 +1,6 @@
 module Sheng
   module Filters
-    class UnsupportedFilterError < StandardError; end
+    class UnsupportedFilterError < Sheng::Error; end
 
     class << self
       def registry

--- a/lib/sheng/merge_field.rb
+++ b/lib/sheng/merge_field.rb
@@ -8,7 +8,7 @@ module Sheng
       key_string: /^(?<prefix>start:|end:|if:|end_if:|unless:|end_unless:)?\s*(?<key>[^\|]+)\s*\|?(?<filters>.*)?/
     }
 
-    class NotAMergeFieldError < StandardError; end
+    class NotAMergeFieldError < Sheng::Error; end
 
     class << self
       def from_element(element)

--- a/lib/sheng/merge_field.rb
+++ b/lib/sheng/merge_field.rb
@@ -18,12 +18,13 @@ module Sheng
       end
     end
 
-    attr_reader :element, :xml_document
+    attr_reader :element, :xml_document, :errors
 
     def initialize(element)
       @element = element
       @xml_document = element.document
       @instruction_text = Sheng::Support.extract_mergefield_instruction_text(element)
+      @errors = []
     end
 
     def ==(other)
@@ -240,7 +241,8 @@ module Sheng
     def interpolate(data_set)
       value = get_value(data_set)
       replace_mergefield(filter_value(value))
-    rescue DataSet::KeyNotFound, Dentaku::UnboundVariableError, Filters::UnsupportedFilterError
+    rescue DataSet::KeyNotFound, Dentaku::UnboundVariableError, Filters::UnsupportedFilterError => e
+      @errors << e
       # Ignore this error; we'll collect all uninterpolated fields later and
       # raise a new exception, so we can list all the fields in an error
       # message.

--- a/lib/sheng/merge_field_set.rb
+++ b/lib/sheng/merge_field_set.rb
@@ -4,17 +4,25 @@ module Sheng
   class MergeFieldSet
     include PathHelpers
 
-    attr_reader :xml_fragment, :xml_document, :key
+    attr_reader :xml_fragment, :xml_document, :key, :errors
 
     def initialize(key, xml_fragment)
       @key = key
       @xml_fragment = xml_fragment
       @xml_document = xml_fragment.document
+      @errors = {}
     end
 
     def interpolate(data_set)
       nodes.each do |node|
         node.interpolate(data_set)
+        add_errors_from_node(node)
+      end
+    end
+
+    def add_errors_from_node(node)
+      if node.errors.present?
+        errors[node.raw_key] = node.errors
       end
     end
 

--- a/lib/sheng/wml_file.rb
+++ b/lib/sheng/wml_file.rb
@@ -1,35 +1,19 @@
 module Sheng
   class WMLFile
-    class InvalidWML < StandardError; end
-    class MergefieldNotReplacedError < StandardError
-      def initialize(unmerged_fields)
-        unmerged_keys = unmerged_fields.map(&:raw_key)
-        super("Mergefields not replaced: #{unmerged_keys.join(', ')}")
-      end
-    end
+    class InvalidWML < Docx::TemplateError; end
 
-    attr_reader :xml, :filename
+    attr_reader :xml, :filename, :errors
 
     def initialize(filename, xml)
       @filename = filename
       @xml = Nokogiri::XML(xml)
+      @errors = {}
     end
 
     def interpolate(data_set)
       parent_set.interpolate(data_set)
-      check_for_full_interpolation!
+      errors.merge!(parent_set.errors)
       parent_set.xml_fragment.to_s
-    end
-
-    def check_for_full_interpolation!
-      modified_parent_set = MergeFieldSet.new('main', xml)
-      unmerged_fields = modified_parent_set.basic_nodes.reject { |node|
-        node.is_a?(CheckBox)
-      }
-
-      unless unmerged_fields.empty?
-        raise MergefieldNotReplacedError.new(unmerged_fields)
-      end
     end
 
     def parent_set

--- a/spec/lib/sheng/check_box_spec.rb
+++ b/spec/lib/sheng/check_box_spec.rb
@@ -71,17 +71,21 @@ describe Sheng::CheckBox do
       expect(default_checked.xml_document).to be_equivalent_to fragment_with_unchecked_box(default_checked.xml_document)
     end
 
-    it "does not check the checkbox if key is not found in dataset" do
-      dataset = Sheng::DataSet.new({})
+    it "records error and does not check the checkbox if key is not found in dataset" do
+      allow(dataset).to receive(:fetch).with("goats").and_raise(Sheng::DataSet::KeyNotFound, "uhoh")
       subject.interpolate(dataset)
       expect(subject.xml_document).to be_equivalent_to fragment_with_unchecked_box(subject.xml_document)
+      expect(subject.errors.first).to be_a(Sheng::DataSet::KeyNotFound)
+      expect(subject.errors.first.message).to eq("uhoh")
     end
 
-    it "does not uncheck a checked checkbox if key is not found in dataset" do
-      dataset = Sheng::DataSet.new({})
+    it "records error and does not uncheck a checked checkbox if key is not found in dataset" do
+      allow(dataset).to receive(:fetch).with("goats").and_raise(Sheng::DataSet::KeyNotFound, "uhoh")
       default_checked = described_class.new(fragment_with_checked_box(subject.xml_document))
       default_checked.interpolate(dataset)
       expect(default_checked.xml_document).to be_equivalent_to xml_fragment('output/check_box/check_box')
+      expect(default_checked.errors.first).to be_a(Sheng::DataSet::KeyNotFound)
+      expect(default_checked.errors.first.message).to eq("uhoh")
     end
   end
 end

--- a/spec/lib/sheng/data_set_spec.rb
+++ b/spec/lib/sheng/data_set_spec.rb
@@ -43,7 +43,7 @@ describe Sheng::DataSet do
     it 'raises a KeyNotFound error if key not found' do
       expect {
         subject.fetch('rabbits.funky')
-      }.to raise_error(described_class::KeyNotFound, "did not find in dataset: rabbits.funky (funky not found)")
+      }.to raise_error(described_class::KeyNotFound, "rabbits.funky (at funky)")
     end
 
     it 'does not raise error on key not found if default given' do

--- a/spec/lib/sheng/docx_spec.rb
+++ b/spec/lib/sheng/docx_spec.rb
@@ -26,7 +26,7 @@ describe Sheng::Docx do
       File.open(output_file, "w").write("nothing")
       expect {
         subject.generate(output_file)
-      }.to raise_error(described_class::FileAlreadyExists)
+      }.to raise_error(described_class::OutputPathAlreadyExists)
     end
 
     it 'overwrites file if file already exists but force option is true' do
@@ -68,7 +68,7 @@ describe Sheng::Docx do
       doc = described_class.new(input_file, incomplete_hash)
       expect {
         doc.generate(output_file)
-      }.to raise_error(Sheng::Docx::GenerateError)
+      }.to raise_error(Sheng::Docx::MergeError)
       expect(doc.errors.keys).to eq(["first_name", "last_name"])
       expect(doc.errors["first_name"].map(&:message)).to eq(["first_name (at first_name)"])
     end
@@ -83,13 +83,13 @@ describe Sheng::Docx do
     end
 
     it_should_behave_like 'a bad document', 'with_field_not_in_dataset.docx',
-      Sheng::Docx::GenerateError, {"extra_name"=>[Sheng::DataSet::KeyNotFound.new("extra_name (at extra_name)")] }.to_s
+      Sheng::Docx::MergeError, {"extra_name"=>[Sheng::DataSet::KeyNotFound.new("extra_name (at extra_name)")] }.to_s
 
     it_should_behave_like 'a bad document', 'with_unended_sequence.docx',
       Sheng::Docx::TemplateError, "no end tag for start:owner_signature"
 
     it_should_behave_like 'a bad document', 'with_missing_sequence_start.docx',
-      Sheng::Docx::GenerateError, {"end:owner_signature"=>[Sheng::DataSet::KeyNotFound.new("owner_signature (at owner_signature)")] }.to_s
+      Sheng::Docx::MergeError, {"end:owner_signature"=>[Sheng::DataSet::KeyNotFound.new("owner_signature (at owner_signature)")] }.to_s
 
     it_should_behave_like 'a bad document', 'with_poorly_nested_sequences.docx',
       Sheng::Docx::TemplateError, "expected end tag for start:birds, got end:animals"


### PR DESCRIPTION
Collect errors from mergefields not interpolating, invalid formulas, missing data, etc on each mergefield, and assemble an error report to include in the generation exception.  Also refactor and rename some errors.